### PR TITLE
feat: close polygon visualization

### DIFF
--- a/polygon_rviz_plugins/src/polygon_parts.cpp
+++ b/polygon_rviz_plugins/src/polygon_parts.cpp
@@ -78,11 +78,16 @@ void PolygonOutline::reset()
 void PolygonOutline::setPolygon(const polygon_msgs::msg::Polygon2D& polygon, const Ogre::ColourValue& color,
                                 double z_offset)
 {
-  manual_object_->estimateVertexCount(polygon.points.size());
+  bool implicit_closed = !polygon.points.empty() && polygon.points.front() != polygon.points.back();
+  manual_object_->estimateVertexCount(polygon.points.size() + (implicit_closed ? 1 : 0));
   manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP);
   for (const polygon_msgs::msg::Point2D& msg_point : polygon.points)
   {
     manual_object_->position(msg_point.x, msg_point.y, z_offset);
+    manual_object_->colour(color);
+  }
+  if (implicit_closed) {
+    manual_object_->position(polygon.points.front().x, polygon.points.front().y, z_offset);
     manual_object_->colour(color);
   }
   manual_object_->end();

--- a/polygon_rviz_plugins/src/polygon_parts.cpp
+++ b/polygon_rviz_plugins/src/polygon_parts.cpp
@@ -86,7 +86,8 @@ void PolygonOutline::setPolygon(const polygon_msgs::msg::Polygon2D& polygon, con
     manual_object_->position(msg_point.x, msg_point.y, z_offset);
     manual_object_->colour(color);
   }
-  if (implicit_closed) {
+  if (implicit_closed)
+  {
     manual_object_->position(polygon.points.front().x, polygon.points.front().y, z_offset);
     manual_object_->colour(color);
   }


### PR DESCRIPTION
If the first and last points of the polygon are not equal for a line strip type visualization, add the first point to the end.

Addresses #15 